### PR TITLE
Fix Python variant in JAX ROCm recipe

### DIFF
--- a/recipes/rocm-jax-plugin/build.sh
+++ b/recipes/rocm-jax-plugin/build.sh
@@ -65,13 +65,13 @@ BUILD_ARGS=(
 
 # Build wheels separately: build.py's subprocess inherits the CWD, and
 # the first bazel run can invalidate it before the second starts.
-python build/build.py build --wheels=jax-rocm-plugin "${BUILD_ARGS[@]}"
-python build/build.py build --wheels=jax-rocm-pjrt "${BUILD_ARGS[@]}"
+$PYTHON build/build.py build --wheels=jax-rocm-plugin "${BUILD_ARGS[@]}"
+$PYTHON build/build.py build --wheels=jax-rocm-pjrt "${BUILD_ARGS[@]}"
 
 # Skip bazel clean to preserve cache across Python variant builds.
 # The output base lives in BUILD_PREFIX and is discarded after the final variant.
 
-pip install --no-deps --prefix="${PREFIX}" dist/*.whl
+$PYTHON -m pip install --no-deps --prefix="${PREFIX}" dist/*.whl
 
 # Fix INSTALLER/RECORD (https://github.com/conda-forge/jaxlib-feedstock#293)
 HOST_SP_DIR=$($PYTHON -c "import sysconfig; print(sysconfig.get_path('purelib'))")

--- a/recipes/rocm-jax-plugin/recipe.yaml
+++ b/recipes/rocm-jax-plugin/recipe.yaml
@@ -2,7 +2,7 @@ context:
   name: jax-rocm7-plugin
   version: "0.7.1"
   rocm_version: "7.0.2"
-  build: 0
+  build: 1
 
 package:
   name: ${{ name }}
@@ -18,6 +18,7 @@ build:
   skip:
     - not linux
     - hip_compiler_version in (None, "None")
+    - match(python, "<3.11")
 
 requirements:
   build:
@@ -37,7 +38,7 @@ requirements:
     - sed
     - patchelf
   host:
-    - python >=3.11
+    - python
     - pip
     - numpy
     - setuptools
@@ -63,7 +64,7 @@ requirements:
     - hipcub
     - numactl
   run:
-    - python >=3.11
+    - python
     - jax >=${{ version }}
     - jaxlib >=${{ version }}
 


### PR DESCRIPTION
By using bare `python` instead of `$PYTHON`, and pinning python version in the host deps (`python >=3.11` instead that skipping `py<311`, we got `python_abi` constraint on 3.14 on all the variants (see https://prefix.dev/channels/rock-the-conda-strix/packages/jax-rocm7-plugin)